### PR TITLE
Use setcmdline() instead of evaluation (c_CTRL-\_e)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         neovim_branch:
-          - v0.6.1
-          - v0.7.0
+          - v0.8.0
+          - v0.8.1
           - master
     runs-on: ubuntu-latest
     env:

--- a/lua/emcl/tests/funcs_spec.lua
+++ b/lua/emcl/tests/funcs_spec.lua
@@ -109,7 +109,7 @@ for _, c in ipairs {
         utils.set_hist(c.h)
       end
       utils.set_linepos(c.b)
-      utils.set_line(funcs[c.m](funcs))
+      funcs[c.m](funcs)
       assert.are.same(utils.expand_linepos(c.a), utils.get_linepos())
       if c.r then
         assert.are.same(c.r, funcs.register)

--- a/lua/emcl/tests/utils.lua
+++ b/lua/emcl/tests/utils.lua
@@ -7,7 +7,8 @@ end
 vim.fn.getcmdpos = function()
   return cmdpos
 end
-vim.fn.setcmdpos = function(pos)
+vim.fn.setcmdline = function(str, pos)
+  cmdline = str
   cmdpos = pos
 end
 vim.fn.histnr = function(_)
@@ -33,10 +34,6 @@ return {
 
   get_linepos = function()
     return { cmdline, cmdpos }
-  end,
-
-  set_line = function(str)
-    cmdline = str
   end,
 
   set_hist = function(h)


### PR DESCRIPTION
Neovim 0.8+ supports a new API `setcmdline()` to set command line string from plugins. This patch uses this to avoid slow evaluation by using `c_CTRL-\_e`.